### PR TITLE
Allow to launch the frontend using native Wayland instead of XWayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ linux-wallpaperengine-gui [options]
 ### [Options]
 
 - `--minimized`: Starts the application minimized in the system tray.
+- `--native-wayland`: Makes electron use native Wayland instead of XWayland to solve fractional scaling issues (only works on Wayland sessions)
 - `--debug-mode`: Enables debug mode for the application.
 
 ## BUILD FROM SOURCE

--- a/src/frontend/main/main.ts
+++ b/src/frontend/main/main.ts
@@ -37,6 +37,7 @@ let cachedWallpaperBasePath = "";
 
 const VITE_DEV_SERVER_URL = process.env["VITE_DEV_SERVER_URL"];
 const isMinimized = process.argv.includes("--minimized");
+export const isNativeWayland = process.argv.includes("--native-wayland");
 const isDebug = process.argv.includes("--debug-mode");
 
 function createWindow() {

--- a/src/frontend/main/utils/waylandHelper.ts
+++ b/src/frontend/main/utils/waylandHelper.ts
@@ -1,4 +1,5 @@
 import { logger } from "../logger";
+import { isNativeWayland } from "../main";
 
 export function isWaylandSession(): boolean {
      const sessionType = process.env.XDG_SESSION_TYPE || "";
@@ -18,13 +19,14 @@ export function getWaylandEnvironment(): NodeJS.ProcessEnv {
      const isWayland = isWaylandSession();
 
      if (isWayland) {
+          const ozoneBackend = isNativeWayland ? "wayland" : "x11";
           logger.backend(
-               "Configuring Electron to use XWayland for better compatibility",
+               `Configuring Electron to use ${isNativeWayland ? "Wayland" : "XWayland for better compatibility"}`,
           );
           return {
-               OZONE_PLATFORM: "x11",
-               GDK_BACKEND: "x11",
-               ELECTRON_OZONE_PLATFORM_HINT: "x11",
+               OZONE_PLATFORM: ozoneBackend,
+               GDK_BACKEND: ozoneBackend,
+               ELECTRON_OZONE_PLATFORM_HINT: ozoneBackend,
           };
      }
 


### PR DESCRIPTION
Added an argument to let the user launch the frontend using native Wayland instead of XWayland to solve fractional scaling issues.

XWayland on a 4k monitor with fractional scaling:
<img width="678" height="168" alt="image" src="https://github.com/user-attachments/assets/7ddc15f6-7705-4188-914d-566b29d2dc22" />

Native wayland on a 4k monitor with fractional scaling:
<img width="721" height="173" alt="image" src="https://github.com/user-attachments/assets/7fb6b0c5-a14f-4a99-b755-210da6125639" />

It's way worse in person than in the photos.