### PR TITLE
Add option to enable autostart

### DIFF
--- a/src/backend/internal/api/handlers/base.go
+++ b/src/backend/internal/api/handlers/base.go
@@ -18,6 +18,8 @@ var dispatchTable = map[string]handlerFn{
 	"write-config":       wrapConfig,
 	"open-config-editor": wrapConfig,
 
+	"toggle-autostart": wrapConfig,
+
 	"get-screens": wrapDisplay,
 
 	"apply-wallpapers":           wrapWallpaper,

--- a/src/backend/internal/api/handlers/config.go
+++ b/src/backend/internal/api/handlers/config.go
@@ -29,6 +29,18 @@ func HandleConfig(req models.Request) models.Response {
 				res.Result = map[string]bool{"success": true}
 			}
 		}
+	case "toggle-autostart":
+		var enabled bool
+		if err := json.Unmarshal(req.Params, &enabled); err != nil {
+			res.Error = err.Error()
+		} else {
+			if err := config.ToggleAutostart(enabled); err != nil {
+				res.Error = err.Error()
+			} else {
+				res.Result = map[string]bool{"success": true}
+			}
+		}
+
 	case "open-config-editor":
 		if err := config.OpenConfigEditor(); err != nil {
 			res.Error = err.Error()

--- a/src/backend/internal/config/config.go
+++ b/src/backend/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 var (
 	HomePath            string
 	ConfigPath          string
+	AutostartPath       string
 	WorkshopPath        string
 	WallpaperEnginePath string
 	DefaultConfig       AppConfig
@@ -24,6 +25,7 @@ func init() {
 	}
 
 	ConfigPath = filepath.Join(HomePath, ".config/linux-wallpaperengine-gui/config.json")
+	AutostartPath = filepath.Join(HomePath, ".config/autostart/linux-wallpaperengine-gui.desktop")
 
 	DefaultConfig = AppConfig{
 		FPS:                 60,
@@ -39,6 +41,7 @@ func init() {
 		Properties:          make(map[string]string),
 		WallpaperProperties: make(map[string]map[string]string),
 		Playlist:            "",
+		Autostart:           false,
 		DynamicUiTheme:      true,
 		DynamicSidebarTheme: true,
 		TransparentUi:       true,
@@ -171,6 +174,32 @@ func WriteConfig(conf AppConfig) error {
 	}
 
 	return os.WriteFile(ConfigPath, data, 0644)
+}
+
+func ToggleAutostart(enabled bool) error {
+	dir := filepath.Dir(AutostartPath)
+	if enabled {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return err
+			}
+		}
+		data := `[Desktop Entry]
+Name=Linux Wallpaper Engine GUI
+Comment=Manage wallpapers for linux-wallpaperengine
+Exec=linux-wallpaperengine-gui --minimized
+Icon=linux-wallpaperengine-gui
+Terminal=false
+Type=Application
+Categories=Utility;
+`
+		return os.WriteFile(AutostartPath, []byte(data), 0644)
+	} else {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			return err
+		}
+		return os.Remove(AutostartPath)
+	}
 }
 
 func GetConfig() (AppConfig, error) {

--- a/src/backend/internal/config/types.go
+++ b/src/backend/internal/config/types.go
@@ -60,6 +60,7 @@ type AppConfig struct {
 	CustomExecutableLocation string         `json:"customExecutableLocation,omitempty"`
 	WorkshopDir              string         `json:"workshopDir,omitempty"`
 	NativeWayland            bool           `json:"nativeWayland,omitempty"`
+	Autostart                bool           `json:"autostart"`
 	DynamicUiTheme           bool           `json:"dynamicUiTheme"`
 	DynamicSidebarTheme      bool           `json:"dynamicSidebarTheme"`
 	TransparentUi            bool           `json:"transparentUi"`

--- a/src/frontend/main/preload.ts
+++ b/src/frontend/main/preload.ts
@@ -43,6 +43,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	readConfig: createInvokeMethod("read-config"),
 	saveConfig: createInvokeMethod("save-config"),
 	writeConfig: createInvokeMethod("write-config"),
+	toggleAutostart: createInvokeMethod("toggle-autostart"),
 	openConfigInEditor: createInvokeMethod("open-config-editor"),
 	getWallpaperExecutableLocation: createInvokeMethod(
 		"get-wallpaper-executable",

--- a/src/frontend/main/services/configService.ts
+++ b/src/frontend/main/services/configService.ts
@@ -34,6 +34,11 @@ export function registerConfigService() {
 		return await socketClient.send("write-config", newConfig);
 	});
 
+	ipcMain.handle("toggle-autostart", async (_, newConfig: boolean) => {
+		logger.ipcReceived("toggle-autostart");
+		return await socketClient.send("toggle-autostart", newConfig);
+	});
+
 	ipcMain.handle("open-config-editor", async () => {
 		logger.ipcReceived("open-config-editor");
 		return await socketClient.send("open-config-editor");

--- a/src/frontend/shared/types.ts
+++ b/src/frontend/shared/types.ts
@@ -57,6 +57,7 @@ export type AppConfig = {
 	playlist?: string;
 	playlistInterval?: number;
 	nativeWayland?: boolean;
+	autostart?: boolean;
 	dynamicUiTheme?: boolean;
 	dynamicSidebarTheme?: boolean;
 	transparentUi?: boolean;

--- a/src/frontend/svelte/components/Settings.svelte
+++ b/src/frontend/svelte/components/Settings.svelte
@@ -5,7 +5,8 @@
 		loadSettings,
 		saveSettings,
 		openConfigFile,
-		validateBinaryFile
+		validateBinaryFile,
+		toggleAutostart
 	} from '../scripts/settings';
 
 	import SettingsSection from './settings/SettingsSection.svelte';
@@ -186,6 +187,12 @@
 	const handleOpenConfig = async () => {
 		await openConfigFile();
 	};
+
+	const handleAutostart = async () => {
+		if ($settingsStore) {
+			await toggleAutostart($settingsStore.autostart);
+		}
+	}
 </script>
 
 <div class="settings-container">
@@ -226,6 +233,18 @@
 					id="general"
 					description="Basic wallpaper engine behavior and performance."
 				>
+					<SettingItem
+						label="Run on system startup"
+						id="autostart"
+						description="Run this GUI to apply wallpapers in the background on system startup."
+					>
+						<Toggle
+							id="autostart"
+							bind:checked={$settingsStore.autostart}
+							onChange={() => handleAutostart()}
+						/>
+					</SettingItem>
+
 					<SettingItem
 						label="Dynamic UI Theme"
 						id="dynamicUiTheme"

--- a/src/frontend/svelte/scripts/settings.ts
+++ b/src/frontend/svelte/scripts/settings.ts
@@ -60,6 +60,7 @@ export interface SettingsState {
 	playlist: string;
 	playlistInterval: number;
 	nativeWayland: boolean;
+	autostart: boolean;
 	dynamicUiTheme: boolean;
 	dynamicSidebarTheme: boolean;
 	transparentUi: boolean;
@@ -97,6 +98,7 @@ const configFieldMap: Record<string, string> = {
 	playlist: "playlist",
 	playlistInterval: "playlistInterval",
 	nativeWayland: "nativeWayland",
+	autostart: "autostart",
 	dynamicUiTheme: "dynamicUiTheme",
 	dynamicSidebarTheme: "dynamicSidebarTheme",
 	transparentUi: "transparentUi",
@@ -156,6 +158,19 @@ export async function saveSettings(settings: SettingsState): Promise<void> {
 		}
 	} catch (e) {
 		showToast(`Error saving settings: ${getErrorMessage(e)}`, "error");
+	}
+}
+
+export async function toggleAutostart(enable: boolean): Promise<void> {
+	try {
+		const result = await window.electronAPI.toggleAutostart(enable);
+		if (result.success) {
+			showToast("Autostart toggled successfully!", "success");
+		} else {
+			showToast(`Error toggling autostart: ${result.error}`, "error");
+		}
+	} catch (e) {
+		showToast(`Error toggling autostart: ${getErrorMessage(e)}`, "error")
 	}
 }
 

--- a/src/frontend/svelte/vite-env.d.ts
+++ b/src/frontend/svelte/vite-env.d.ts
@@ -37,6 +37,7 @@ interface ElectronAPI {
 	getConfig: () => Promise<any>;
 	readConfig: () => Promise<any>;
 	saveConfig: (newConfig: any) => Promise<{ success: boolean; error?: string }>;
+	toggleAutostart: (enable: boolean) => Promise<{ success: boolean; error?: string }>;
 	writeConfig: (newConfig: any) => Promise<void>;
 	openConfigInEditor: () => Promise<{ success: boolean; error?: string }>;
 	getWallpaperExecutableLocation: () => Promise<string>;


### PR DESCRIPTION
Creates a .desktop file on ~/.config/autostart when enabled, deletes that file when disabled. The GUI is setup to start minimized when this option is enabled, which is useful for users that want to have wallpapers automatically setup on system startup.

I couldn't get the binary to work properly as a systemd service, so the best I could do was setup an autostart. This should work on desktop environments that implement XDG Autostart. I tested only on CachyOS with KDE Plasma.