### PR TITLE
feat: add configurable shell command hook on wallpaper change

### DIFF
--- a/src/backend/internal/config/config.go
+++ b/src/backend/internal/config/config.go
@@ -47,6 +47,8 @@ func init() {
 		TransparentUi:       true,
 		UiTransparency:      90,
 		EnableScrollMask:    true,
+		HookEnabled:              false,
+		WallpaperChangeCommand:   "",
 		SteamPaths: []string{
 			".local/share/Steam",
 			".var/app/com.valvesoftware.Steam/.local/share/Steam",

--- a/src/backend/internal/config/types.go
+++ b/src/backend/internal/config/types.go
@@ -67,6 +67,8 @@ type AppConfig struct {
 	UiTransparency           int            `json:"uiTransparency,omitempty"`
 	SteamPaths               []string       `json:"steamPaths,omitempty"`
 	EnableScrollMask         bool           `json:"enableScrollMask"`
+	HookEnabled              bool           `json:"hookEnabled"`
+	WallpaperChangeCommand   string         `json:"wallpaperChangeCommand,omitempty"`
 
 	// Fixed Filters
 	InstalledFilters *FilterConfig `json:"installedFilters,omitempty"`

--- a/src/backend/internal/core/wallpaper/service.go
+++ b/src/backend/internal/core/wallpaper/service.go
@@ -3,6 +3,7 @@ package wallpaper
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 
 type Service struct {
 	processManager *process.Manager
+	wallpapers     map[string]WallpaperData
 }
 
 func NewService(processManager *process.Manager) *Service {
@@ -64,6 +66,53 @@ func (service *Service) ApplyWallpapers() error {
 	}
 
 	service.processManager.UpdateWallpapers(desiredWallpapers)
+
+	if appConfig.HookEnabled && appConfig.WallpaperChangeCommand != "" {
+		if service.wallpapers == nil {
+			service.wallpapers, _ = GetWallpapers()
+		}
+
+		for _, screen := range activeScreens {
+			wallpaperID := service.getEffectiveWallpaperID(appConfig, screen)
+			if wallpaperID == "" {
+				continue
+			}
+
+			wd, ok := service.wallpapers[wallpaperID]
+			if !ok || wd.ProjectData == nil || wd.ProjectData.Preview == "" {
+				continue
+			}
+			pd := wd.ProjectData
+
+			previewPath := filepath.Join(config.WorkshopPath, wallpaperID, pd.Preview)
+			var videoPath string
+			isVideo := "false"
+			if pd.Type == "Video" && pd.File != "" {
+				videoPath = filepath.Join(config.WorkshopPath, wallpaperID, pd.File)
+				isVideo = "true"
+			}
+
+			cmd := appConfig.WallpaperChangeCommand
+			cmd = strings.ReplaceAll(cmd, "$PREVIEW_PATH", previewPath)
+			cmd = strings.ReplaceAll(cmd, "$VIDEO_PATH", videoPath)
+			cmd = strings.ReplaceAll(cmd, "$IS_VIDEO", isVideo)
+			cmd = strings.ReplaceAll(cmd, "$WALLPAPER_TITLE", pd.Title)
+			cmd = strings.ReplaceAll(cmd, "$WALLPAPER_TYPE", pd.Type)
+			cmd = strings.ReplaceAll(cmd, "$WALLPAPER_ID", wallpaperID)
+			cmd = strings.ReplaceAll(cmd, "$SCREEN_NAME", screen.Name)
+			logger.Printf("Running hook command for %s on %s: %s", wallpaperID, screen.Name, cmd)
+
+			go func(c, id, screenName string) {
+				out, err := exec.Command("sh", "-c", c).CombinedOutput()
+				if err != nil {
+					logger.Printf("hook command failed for %s on %s: %v\n%s", id, screenName, err, string(out))
+				} else {
+					logger.Printf("hook command succeeded for %s on %s\n%s", id, screenName, string(out))
+				}
+			}(cmd, wallpaperID, screen.Name)
+		}
+	}
+
 	return nil
 }
 
@@ -222,6 +271,7 @@ func (service *Service) LoadWallpapers() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	service.wallpapers = wallpapers
 
 	appConfig, _ := config.GetConfig()
 	workshopPathValid := false

--- a/src/backend/internal/core/wallpaper/service.go
+++ b/src/backend/internal/core/wallpaper/service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"linux-wallpaperengine-gui/src/backend/internal/config"
@@ -49,6 +50,8 @@ func (service *Service) ApplyWallpapers() error {
 
 	desiredWallpapers := []struct {
 		Screen  string
+		Exec    string
+		Args    []string
 		Command string
 	}{}
 
@@ -58,11 +61,13 @@ func (service *Service) ApplyWallpapers() error {
 			continue
 		}
 
-		command := service.buildWallpaperCommand(appConfig, screen.Name, wallpaperID)
+		execPath, args, cmdStr := service.buildWallpaperCommand(appConfig, screen.Name, wallpaperID)
 		desiredWallpapers = append(desiredWallpapers, struct {
 			Screen  string
+			Exec    string
+			Args    []string
 			Command string
-		}{Screen: screen.Name, Command: command})
+		}{Screen: screen.Name, Exec: execPath, Args: args, Command: cmdStr})
 	}
 
 	service.processManager.UpdateWallpapers(desiredWallpapers)
@@ -103,7 +108,14 @@ func (service *Service) ApplyWallpapers() error {
 			logger.Printf("Running hook command for %s on %s: %s", wallpaperID, screen.Name, cmd)
 
 			go func(c, id, screenName string) {
-				out, err := exec.Command("sh", "-c", c).CombinedOutput()
+				parts := strings.Fields(c)
+				if len(parts) == 0 {
+					logger.Printf("hook command empty for %s on %s", id, screenName)
+					return
+				}
+				execPath := parts[0]
+				args := parts[1:]
+				out, err := exec.Command(execPath, args...).CombinedOutput()
 				if err != nil {
 					logger.Printf("hook command failed for %s on %s: %v\n%s", id, screenName, err, string(out))
 				} else {
@@ -175,7 +187,7 @@ func (service *Service) getEffectiveWallpaperID(appConfig config.AppConfig, scre
 	return ""
 }
 
-func (service *Service) buildWallpaperCommand(appConfig config.AppConfig, screenName string, wallpaperID string) string {
+func (service *Service) buildWallpaperCommand(appConfig config.AppConfig, screenName string, wallpaperID string) (string, []string, string) {
 	fps := appConfig.FPS
 	if fps == 0 {
 		fps = 60
@@ -186,17 +198,18 @@ func (service *Service) buildWallpaperCommand(appConfig config.AppConfig, screen
 		executable = "linux-wallpaperengine"
 	}
 
-	wallpaperPath := fmt.Sprintf("\"%s\"", wallpaperID)
+	wallpaperPath := wallpaperID
 	if config.WorkshopPath != "" {
-		wallpaperPath = fmt.Sprintf("\"%s\"", filepath.Join(config.WorkshopPath, wallpaperID))
+		wallpaperPath = filepath.Join(config.WorkshopPath, wallpaperID)
 	}
 
-	arguments := []string{wallpaperPath, "-r", screenName, fmt.Sprintf("-f %d", fps)}
+	// Build arguments as a slice to avoid shell interpolation
+	arguments := []string{wallpaperPath, "-r", screenName, "-f", strconv.Itoa(fps)}
 
 	if appConfig.Silence {
 		arguments = append(arguments, "-s")
 	} else if appConfig.Volume != nil {
-		arguments = append(arguments, fmt.Sprintf("--volume %d", int(*appConfig.Volume)))
+		arguments = append(arguments, "--volume", strconv.Itoa(int(*appConfig.Volume)))
 	}
 
 	if appConfig.NoAutomute {
@@ -206,10 +219,10 @@ func (service *Service) buildWallpaperCommand(appConfig config.AppConfig, screen
 		arguments = append(arguments, "--no-audio-processing")
 	}
 	if appConfig.Scaling != "" {
-		arguments = append(arguments, fmt.Sprintf("--scaling %s", appConfig.Scaling))
+		arguments = append(arguments, "--scaling", appConfig.Scaling)
 	}
 	if appConfig.Clamping != "" {
-		arguments = append(arguments, fmt.Sprintf("--clamp %s", appConfig.Clamping))
+		arguments = append(arguments, "--clamp", appConfig.Clamping)
 	}
 	if appConfig.DisableMouse {
 		arguments = append(arguments, "--disable-mouse")
@@ -228,21 +241,21 @@ func (service *Service) buildWallpaperCommand(appConfig config.AppConfig, screen
 	}
 
 	for _, applicationID := range appConfig.FullscreenPauseIgnoreAppIds {
-		arguments = append(arguments, fmt.Sprintf("--fullscreen-pause-ignore-appid %s", applicationID))
+		arguments = append(arguments, "--fullscreen-pause-ignore-appid", applicationID)
 	}
 
 	if appConfig.Screenshot != "" {
-		arguments = append(arguments, fmt.Sprintf("--screenshot \"%s\"", appConfig.Screenshot))
+		arguments = append(arguments, "--screenshot", appConfig.Screenshot)
 
 		if appConfig.ScreenshotDelay != 0 {
-			arguments = append(arguments, fmt.Sprintf("--screenshot-delay %d", appConfig.ScreenshotDelay))
+			arguments = append(arguments, "--screenshot-delay", strconv.Itoa(appConfig.ScreenshotDelay))
 		}
 	}
 
 	if appConfig.WallpaperEngineDir != "" {
-		arguments = append(arguments, fmt.Sprintf("--assets-dir \"%s\"", appConfig.WallpaperEngineDir+"/assets"))
+		arguments = append(arguments, "--assets-dir", appConfig.WallpaperEngineDir+"/assets")
 	} else if config.WallpaperEnginePath != "" {
-		arguments = append(arguments, fmt.Sprintf("--assets-dir \"%s\"", config.WallpaperEnginePath+"/assets"))
+		arguments = append(arguments, "--assets-dir", config.WallpaperEnginePath+"/assets")
 	}
 
 	if appConfig.DumpStructure {
@@ -256,14 +269,17 @@ func (service *Service) buildWallpaperCommand(appConfig config.AppConfig, screen
 	}
 
 	for key, value := range properties {
-		arguments = append(arguments, fmt.Sprintf("--set-property %s=\"%s\"", key, value))
+		arguments = append(arguments, "--set-property", fmt.Sprintf("%s=%s", key, value))
 	}
 
+	// Parse custom args using simple whitespace splitting. Note: quoted args not fully supported.
 	if appConfig.CustomArgsEnabled && appConfig.CustomArgs != "" {
-		arguments = append(arguments, appConfig.CustomArgs)
+		customParts := strings.Fields(appConfig.CustomArgs)
+		arguments = append(arguments, customParts...)
 	}
 
-	return fmt.Sprintf("%s %s", executable, strings.Join(arguments, " "))
+	cmdStr := fmt.Sprintf("%s %s", executable, strings.Join(arguments, " "))
+	return executable, arguments, cmdStr
 }
 
 func (service *Service) LoadWallpapers() (map[string]interface{}, error) {
@@ -319,5 +335,3 @@ func (service *Service) LoadWallpapers() (map[string]interface{}, error) {
 		"wallpaperEnginePathValid": wallpaperEnginePathValid,
 	}, nil
 }
-
-

--- a/src/backend/internal/platform/process/manager.go
+++ b/src/backend/internal/platform/process/manager.go
@@ -29,6 +29,8 @@ func NewManager() *Manager {
 
 func (manager *Manager) UpdateWallpapers(desiredWallpapers []struct {
 	Screen  string
+	Exec    string
+	Args    []string
 	Command string
 }) {
 	manager.mutex.Lock()
@@ -58,8 +60,8 @@ func (manager *Manager) UpdateWallpapers(desiredWallpapers []struct {
 			manager.killWallpaperInternal(desiredWallpaper.Screen)
 		}
 
-		logger.Printf("Starting wallpaper for %s... (%s)", desiredWallpaper.Screen, desiredWallpaper.Command)
-		manager.spawnWallpaper(desiredWallpaper.Screen, desiredWallpaper.Command)
+		logger.Printf("Starting wallpaper for %s... (%s %v)", desiredWallpaper.Screen, desiredWallpaper.Exec, desiredWallpaper.Args)
+		manager.spawnWallpaper(desiredWallpaper.Screen, desiredWallpaper.Exec, desiredWallpaper.Args, desiredWallpaper.Command)
 	}
 }
 
@@ -98,8 +100,8 @@ func (manager *Manager) KillByFolderName(folderName string) {
 	}
 }
 
-func (manager *Manager) spawnWallpaper(screen string, fullCommand string) {
-	command := exec.Command("sh", "-c", fullCommand)
+func (manager *Manager) spawnWallpaper(screen string, execPath string, args []string, fullCommand string) {
+	command := exec.Command(execPath, args...)
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdout, _ := command.StdoutPipe()

--- a/src/frontend/shared/types.ts
+++ b/src/frontend/shared/types.ts
@@ -63,6 +63,8 @@ export type AppConfig = {
 	transparentUi?: boolean;
 	uiTransparency?: number;
 	steamPaths?: string[];
+	hookEnabled?: boolean;
+	wallpaperChangeCommand?: string;
 };
 
 export type PropertyType =

--- a/src/frontend/svelte/app.scss
+++ b/src/frontend/svelte/app.scss
@@ -209,3 +209,8 @@ hr {
 .spin {
      animation: spin 1s linear infinite;
 }
+
+::selection {
+	background-color: var(--bg-app);
+	color: var(--text-inverse);
+}

--- a/src/frontend/svelte/components/settings/Advanced.svelte
+++ b/src/frontend/svelte/components/settings/Advanced.svelte
@@ -66,4 +66,31 @@
 			</div>
 		</SettingItem>
 	{/if}
+
+	<!-- Hooks: add more hook items below as needed -->
+	<SettingItem
+		label="Hooks"
+		id="hookEnabled"
+		description="Enable hooks."
+	>
+		<Toggle
+			id="hookEnabled"
+			bind:checked={$settingsStore.hookEnabled}
+		/>
+	</SettingItem>
+
+	{#if $settingsStore.hookEnabled}
+		<SettingItem
+			label="On wallpaper change"
+			id="wallpaperChangeCommand"
+			vertical
+			description="Shell command. Variables: $PREVIEW_PATH, $VIDEO_PATH, $IS_VIDEO, $WALLPAPER_TITLE, $WALLPAPER_TYPE, $WALLPAPER_ID, $SCREEN_NAME."
+		>
+			<Input
+				id="wallpaperChangeCommand"
+				bind:value={$settingsStore.wallpaperChangeCommand}
+				placeholder='e.g. matugen image "$PREVIEW_PATH" -j'
+			/>
+		</SettingItem>
+	{/if}
 {/if}

--- a/src/frontend/svelte/components/settings/Advanced.svelte
+++ b/src/frontend/svelte/components/settings/Advanced.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
+	import Button from '@/components/shared/ui/Button.svelte';
+	import CopyableCode from '@/components/shared/ui/CopyableCode.svelte';
+	import Icon from '@/components/shared/ui/Icon.svelte';
+	import Input from '@/components/shared/ui/Input.svelte';
 	import SettingItem from '@/components/shared/ui/SettingItem.svelte';
 	import Toggle from '@/components/shared/ui/Toggle.svelte';
-	import Input from '@/components/shared/ui/Input.svelte';
-	import Button from '@/components/shared/ui/Button.svelte';
-	import Icon from '@/components/shared/ui/Icon.svelte';
-	import { settingsStore, saveSettings } from '@/scripts/settings/settings';
+	import { saveSettings, settingsStore } from '@/scripts/settings/settings';
 
 	async function handleRestart() {
-		if (confirm('Changing Wayland support requires a restart. Do you want to restart now?')) {
+		if (
+			confirm(
+				'Changing Wayland support requires a restart. Do you want to restart now?'
+			)
+		) {
 			if ($settingsStore) {
 				await saveSettings($settingsStore);
 				window.electronAPI.restartUI();
@@ -29,10 +34,7 @@
 		/>
 	</SettingItem>
 
-	<SettingItem
-		label="Enable Custom Arguments"
-		id="customArgsEnabled"
-	>
+	<SettingItem label="Enable Custom Arguments" id="customArgsEnabled">
 		<Toggle
 			id="customArgsEnabled"
 			bind:checked={$settingsStore.customArgsEnabled}
@@ -68,15 +70,8 @@
 	{/if}
 
 	<!-- Hooks: add more hook items below as needed -->
-	<SettingItem
-		label="Hooks"
-		id="hookEnabled"
-		description="Enable hooks."
-	>
-		<Toggle
-			id="hookEnabled"
-			bind:checked={$settingsStore.hookEnabled}
-		/>
+	<SettingItem label="Hooks" id="hookEnabled" description="Enable hooks.">
+		<Toggle id="hookEnabled" bind:checked={$settingsStore.hookEnabled} />
 	</SettingItem>
 
 	{#if $settingsStore.hookEnabled}
@@ -84,13 +79,99 @@
 			label="On wallpaper change"
 			id="wallpaperChangeCommand"
 			vertical
-			description="Shell command. Variables: $PREVIEW_PATH, $VIDEO_PATH, $IS_VIDEO, $WALLPAPER_TITLE, $WALLPAPER_TYPE, $WALLPAPER_ID, $SCREEN_NAME."
+			description="Shell command to execute when a wallpaper is applied."
 		>
+			<div class="table-container">
+				<table class="variable-table">
+					<thead>
+						<tr>
+							<th>Variable</th>
+							<th>Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								<CopyableCode code="$PREVIEW_PATH" />
+							</td>
+							<td>Absolute path to the wallpaper's preview image.</td>
+						</tr>
+						<tr>
+							<td>
+								<CopyableCode code="$VIDEO_PATH" />
+							</td>
+							<td>Absolute path to the main media file (video/html).</td>
+						</tr>
+						<tr>
+							<td>
+								<CopyableCode code="$IS_VIDEO" />
+							</td>
+							<td>Boolean indicating if wallpaper is video.</td>
+						</tr>
+						<tr>
+							<td>
+								<CopyableCode code="$WALLPAPER_TITLE" />
+							</td>
+							<td>Display name or title of the wallpaper.</td>
+						</tr>
+						<tr>
+							<td>
+								<CopyableCode code="$WALLPAPER_TYPE" />
+							</td>
+							<td>Type of the wallpaper (video, web, scene).</td>
+						</tr>
+						<tr>
+							<td>
+								<CopyableCode code="$WALLPAPER_ID" />
+							</td>
+							<td>Unique Steam Workshop ID.</td>
+						</tr>
+						<tr>
+							<td>
+								<CopyableCode code="$SCREEN_NAME" />
+							</td>
+							<td>Monitor/screen name (e.g., DP-1).</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 			<Input
 				id="wallpaperChangeCommand"
 				bind:value={$settingsStore.wallpaperChangeCommand}
-				placeholder='e.g. matugen image "$PREVIEW_PATH" -j'
+				placeholder="e.g. matugen image '$PREVIEW_PATH' -j"
 			/>
 		</SettingItem>
 	{/if}
 {/if}
+
+<style lang="scss">
+	.table-container {
+		width: 100%;
+		overflow-x: auto;
+		margin-bottom: 12px;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border-color);
+	}
+
+	.variable-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.85em;
+
+		th,
+		td {
+			padding: 10px 14px;
+			text-align: left;
+			border-bottom: 1px solid var(--border-color);
+		}
+
+		th {
+			font-weight: 600;
+			color: var(--text-color);
+		}
+
+		tr:last-child td {
+			border-bottom: none;
+		}
+	}
+</style>

--- a/src/frontend/svelte/components/settings/General.svelte
+++ b/src/frontend/svelte/components/settings/General.svelte
@@ -64,6 +64,7 @@
 		/>
 	</SettingItem>
 
+
 	<SettingItem
 		label="Transparent UI"
 		id="transparentUi"

--- a/src/frontend/svelte/components/shared/ui/CopyableCode.svelte
+++ b/src/frontend/svelte/components/shared/ui/CopyableCode.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import Icon from './Icon.svelte';
+	import { showToast } from '@/scripts/shared/toastStore';
+
+	export let code: string;
+
+	async function copyToClipboard() {
+		try {
+			await navigator.clipboard.writeText(code);
+			showToast('Copied to clipboard!', 'success');
+		} catch (err) {
+			console.error('Failed to copy text: ', err);
+			showToast('Failed to copy text.', 'error');
+		}
+	}
+</script>
+
+<div class="copyable">
+	<code>{code}</code>
+	<button class="copy-btn" on:click={copyToClipboard} title="Copy">
+		<Icon name="content_copy" size={14} />
+	</button>
+</div>
+
+<style lang="scss">
+	.copyable {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	code {
+		background: var(--bg-app);
+		padding: 4px 8px;
+		border-radius: var(--radius-sm);
+		font-family: monospace;
+		color: var(--text-color);
+	}
+
+	.copy-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		border: none;
+		padding: 4px;
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		cursor: pointer;
+		transition: var(--transition-base);
+
+		&:hover {
+			color: var(--text-color);
+			background: var(--bg-surface-hover);
+		}
+	}
+</style>

--- a/src/frontend/svelte/scripts/settings/settings.ts
+++ b/src/frontend/svelte/scripts/settings/settings.ts
@@ -45,6 +45,8 @@ export interface SettingsState {
 	uiTransparency: number;
 	steamPaths: string[];
 	enableScrollMask: boolean;
+	hookEnabled: boolean;
+	wallpaperChangeCommand: string;
 }
 
 export const settingsStore: Writable<SettingsState | null> = writable(null);
@@ -83,6 +85,8 @@ const configFieldMap: Record<string, string> = {
 	uiTransparency: "uiTransparency",
 	steamPaths: "steamPaths",
 	enableScrollMask: "enableScrollMask",
+	hookEnabled: "hookEnabled",
+	wallpaperChangeCommand: "wallpaperChangeCommand",
 };
 
 // Settings Actions


### PR DESCRIPTION
Add a configurable shell command hook that runs on wallpaper change.
- New "Hooks" section in Advanced settings with "On wallpaper change" sub-hook
- Template variables: `$PREVIEW_PATH`, `$VIDEO_PATH`, `$IS_VIDEO`, `$WALLPAPER_TITLE`, `$WALLPAPER_TYPE`, `$WALLPAPER_ID`, `$SCREEN_NAME`
- Executes in Go backend daemon (works without GUI)
- Extensible design for future hook types