### PR TITLE
feat: add config option to hide system tray label

### DIFF
--- a/src/backend/internal/api/handlers/config.go
+++ b/src/backend/internal/api/handlers/config.go
@@ -5,6 +5,7 @@ import (
 
 	"linux-wallpaperengine-gui/src/backend/internal/api/models"
 	"linux-wallpaperengine-gui/src/backend/internal/config"
+	"linux-wallpaperengine-gui/src/backend/internal/ui/tray"
 )
 
 func (handler *Handler) HandleConfig(request models.Request) models.Response {
@@ -27,6 +28,7 @@ func (handler *Handler) HandleConfig(request models.Request) models.Response {
 			if err := config.WriteConfig(appConfig); err != nil {
 				response.Error = err.Error()
 			} else {
+				tray.UpdateTitle(appConfig.HideTrayLabel)
 				response.Result = map[string]bool{"success": true}
 			}
 		}

--- a/src/backend/internal/config/config.go
+++ b/src/backend/internal/config/config.go
@@ -48,6 +48,7 @@ func init() {
 		UiTransparency:      90,
 		EnableScrollMask:    true,
 		HookEnabled:              false,
+		HideTrayLabel:            false,
 		WallpaperChangeCommand:   "",
 		SteamPaths: []string{
 			".local/share/Steam",

--- a/src/backend/internal/config/types.go
+++ b/src/backend/internal/config/types.go
@@ -68,6 +68,7 @@ type AppConfig struct {
 	SteamPaths               []string       `json:"steamPaths,omitempty"`
 	EnableScrollMask         bool           `json:"enableScrollMask"`
 	HookEnabled              bool           `json:"hookEnabled"`
+	HideTrayLabel            bool           `json:"hideTrayLabel"`
 	WallpaperChangeCommand   string         `json:"wallpaperChangeCommand,omitempty"`
 
 	// Fixed Filters

--- a/src/backend/internal/ui/tray/tray.go
+++ b/src/backend/internal/ui/tray/tray.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"linux-wallpaperengine-gui/src/backend/internal/config"
+
 	"github.com/getlantern/systray"
 )
 
@@ -57,8 +59,15 @@ func onReady() {
 		fmt.Printf("[BACKEND] ERROR: Tray icon not found. Searched in: %v\n", iconPaths)
 	}
 
-	systray.SetTooltip("Linux Wallpaper Engine GUI")
-	systray.SetTitle("Linux Wallpaper Engine GUI")
+	// Optionally hide the tray label per user config
+	appConfig, err := config.ReadConfig()
+	if err == nil && appConfig.HideTrayLabel {
+		systray.SetTitle("")
+		systray.SetTooltip("")
+	} else {
+		systray.SetTooltip("Linux Wallpaper Engine GUI")
+		systray.SetTitle("Linux Wallpaper Engine GUI")
+	}
 
 	mShow := systray.AddMenuItem("Show", "Open the GUI")
 	mClose := systray.AddMenuItem("Hide", "Hide the GUI to system tray")

--- a/src/backend/internal/ui/tray/tray.go
+++ b/src/backend/internal/ui/tray/tray.go
@@ -103,6 +103,17 @@ func onExit() {
 	// Cleanup if needed
 }
 
+// UpdateTitle sets or hides the tray label at runtime (no restart needed).
+func UpdateTitle(hide bool) {
+	if hide {
+		systray.SetTitle("")
+		systray.SetTooltip("")
+	} else {
+		systray.SetTooltip("Linux Wallpaper Engine GUI")
+		systray.SetTitle("Linux Wallpaper Engine GUI")
+	}
+}
+
 func Quit() {
 	systray.Quit()
 }

--- a/src/frontend/shared/types.ts
+++ b/src/frontend/shared/types.ts
@@ -65,6 +65,7 @@ export type AppConfig = {
 	uiTransparency?: number;
 	steamPaths?: string[];
 	hookEnabled?: boolean;
+	hideTrayLabel?: boolean;
 	wallpaperChangeCommand?: string;
 };
 

--- a/src/frontend/svelte/core/i18n/locales/en/settings.json
+++ b/src/frontend/svelte/core/i18n/locales/en/settings.json
@@ -32,7 +32,9 @@
 		"disableParticles": "Disable Particles",
 		"disableParticlesDesc": "Turn off particle effects to save resources.",
 		"scrollMask": "Scroll Mask Effect",
-		"scrollMaskDesc": "Enable smooth fade effect at the top and bottom of scroll areas. (Note: May impact performance on some systems)"
+		"scrollMaskDesc": "Enable smooth fade effect at the top and bottom of scroll areas. (Note: May impact performance on some systems)",
+		"hideTrayLabel": "Hide Tray Label",
+		"hideTrayLabelDesc": "Show only the icon in the system tray, hiding the \"Linux Wallpaper Engine\" text."
 	},
 	"generalScaling": {
 		"default": "Default",

--- a/src/frontend/svelte/core/i18n/locales/zh/settings.json
+++ b/src/frontend/svelte/core/i18n/locales/zh/settings.json
@@ -32,7 +32,9 @@
 		"disableParticles": "禁用粒子效果",
 		"disableParticlesDesc": "关闭粒子效果以节省资源。",
 		"scrollMask": "滚动遮罩效果",
-		"scrollMaskDesc": "在滚动区域的顶部和底部启用平滑淡入淡出效果。（注意：可能影响部分系统性能）"
+		"scrollMaskDesc": "在滚动区域的顶部和底部启用平滑淡入淡出效果。（注意：可能影响部分系统性能）",
+		"hideTrayLabel": "隐藏托盘标签",
+		"hideTrayLabelDesc": "在系统托盘中仅显示图标，隐藏\"Linux Wallpaper Engine\"文字。"
 	},
 	"generalScaling": {
 		"default": "默认",

--- a/src/frontend/svelte/core/i18n/types.ts
+++ b/src/frontend/svelte/core/i18n/types.ts
@@ -43,6 +43,8 @@ export type I18nKey =
 	| 'settings.general.disableParticlesDesc'
 	| 'settings.general.scrollMask'
 	| 'settings.general.scrollMaskDesc'
+	| 'settings.general.hideTrayLabel'
+	| 'settings.general.hideTrayLabelDesc'
 	| 'settings.generalScaling.default'
 	| 'settings.generalScaling.stretch'
 	| 'settings.generalScaling.fit'

--- a/src/frontend/svelte/features/settings/components/General.svelte
+++ b/src/frontend/svelte/features/settings/components/General.svelte
@@ -181,4 +181,15 @@
 			bind:checked={$settingsStore.enableScrollMask}
 		/>
 	</SettingItem>
+
+	<SettingItem
+		label={$t('settings.general.hideTrayLabel')}
+		id="hideTrayLabel"
+		description={$t('settings.general.hideTrayLabelDesc')}
+	>
+		<Toggle
+			id="hideTrayLabel"
+			bind:checked={$settingsStore.hideTrayLabel}
+		/>
+	</SettingItem>
 {/if}

--- a/src/frontend/svelte/features/settings/scripts/settings.ts
+++ b/src/frontend/svelte/features/settings/scripts/settings.ts
@@ -46,6 +46,7 @@ export interface SettingsState {
 	steamPaths: string[];
 	enableScrollMask: boolean;
 	hookEnabled: boolean;
+	hideTrayLabel: boolean;
 	wallpaperChangeCommand: string;
 }
 
@@ -86,6 +87,7 @@ const configFieldMap: Record<string, string> = {
 	steamPaths: "steamPaths",
 	enableScrollMask: "enableScrollMask",
 	hookEnabled: "hookEnabled",
+	hideTrayLabel: "hideTrayLabel",
 	wallpaperChangeCommand: "wallpaperChangeCommand",
 };
 


### PR DESCRIPTION
## What

Adds a **"Hide Tray Label"** toggle in Settings → General that hides the "Linux Wallpaper Engine GUI" text from the system tray, leaving only the icon visible. The change takes effect **instantly** — no restart required.

Fixes #49.

## Changes

### Backend (Go)

| File | Change |
|------|--------|
| `config/types.go` | Added `HideTrayLabel bool` field to `AppConfig` |
| `config/config.go` | Default value `HideTrayLabel: false` |
| `ui/tray/tray.go` | Reads config on startup to decide tray label visibility; added exported `UpdateTitle(hide bool)` for runtime updates |
| `api/handlers/config.go` | Calls `tray.UpdateTitle()` on successful config write so the tray updates immediately |

### Frontend (Svelte/TypeScript)

| File | Change |
|------|--------|
| `shared/types.ts` | Added `hideTrayLabel?: boolean` to `AppConfig` type |
| `settings/settings.ts` | Added field to `SettingsState` and `configFieldMap` |
| `General.svelte` | Added Toggle UI for the new setting |
| `i18n/types.ts` | New i18n keys |
| `i18n/en/settings.json` | English translations |
| `i18n/zh/settings.json` | Chinese translations |

## How it works

1. User toggles "Hide Tray Label" in Settings → General
2. Config is saved with `"hideTrayLabel": true`
3. The config handler calls `tray.UpdateTitle(true)` which immediately clears the tray title/tooltip
4. On next startup, `tray.onReady()` reads the config and skips setting the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
