### PR TITLE
ci: keep AppStream release metadata in sync

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,3 +79,33 @@ jobs:
                          dist/latest-linux.yml
                env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+             - name: Read published release date
+               if: startsWith(github.ref, 'refs/tags/v')
+               env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+               run: |
+                    release_date="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" --jq '.published_at | split("T")[0]')"
+                    echo "RELEASE_DATE=${release_date}" >> "$GITHUB_ENV"
+
+             - name: Update AppStream release history
+               if: startsWith(github.ref, 'refs/tags/v')
+               run: |
+                    git fetch origin dev
+                    git checkout -B dev origin/dev
+
+                    bun utils/update-appstream-releases.ts \
+                      --version "$GITHUB_REF_NAME" \
+                      --date "$RELEASE_DATE"
+
+                    metadata='packaging/io.github.AzPepoze.linux-wallpaperengine-gui.metainfo.xml'
+                    if git diff --quiet -- "$metadata"; then
+                      exit 0
+                    fi
+
+                    git config user.name 'github-actions[bot]'
+                    git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+                    git add "$metadata"
+                    git commit -m "chore: update AppStream releases for ${GITHUB_REF_NAME}"
+                    git pull --rebase origin dev
+                    git push origin HEAD:dev

--- a/utils/update-appstream-releases.ts
+++ b/utils/update-appstream-releases.ts
@@ -1,0 +1,47 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const metadataPath = 'packaging/io.github.AzPepoze.linux-wallpaperengine-gui.metainfo.xml';
+const maxReleases = 3;
+
+function readArg(name: string): string {
+    const index = process.argv.indexOf(name);
+    const value = process.argv[index + 1];
+
+    if (index === -1 || !value) {
+        throw new Error(`Missing required argument: ${name}`);
+    }
+
+    return value;
+}
+
+const version = readArg('--version').replace(/^v/, '');
+const date = readArg('--date');
+
+if (!/^[0-9A-Za-z.+_-]+$/.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+}
+
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Invalid release date: ${date}`);
+}
+
+const xml = readFileSync(metadataPath, 'utf8');
+const releasesMatch = xml.match(/<releases>\s*([\s\S]*?)\s*<\/releases>/);
+
+if (!releasesMatch) {
+    throw new Error(`Could not find <releases> in ${metadataPath}`);
+}
+
+const existing = [...releasesMatch[1].matchAll(/<release\s+version="([^"]+)"\s+date="([^"]+)"\s*\/>/g)]
+    .map((match) => ({ version: match[1], date: match[2] }))
+    .filter((release) => release.version !== version);
+
+const releases = [{ version, date }, ...existing].slice(0, maxReleases);
+const replacement = `<releases>\n${releases
+    .map((release) => `    <release version="${release.version}" date="${release.date}"/>`)
+    .join('\n')}\n  </releases>`;
+
+const updated = xml.replace(/<releases>\s*[\s\S]*?\s*<\/releases>/, replacement);
+writeFileSync(metadataPath, updated);
+
+console.log(`Updated AppStream releases with ${version} (${date})`);


### PR DESCRIPTION
## What changed

- add `utils/update-appstream-releases.ts` to update the AppStream `<releases>` block
- hook it into the existing tag release workflow after the GitHub Release is published
- use the release's actual `published_at` date from the GitHub API
- de-duplicate the current version and keep the latest three release entries
- commit the metadata update back to `dev` as `github-actions[bot]`

## Why

PR #57 adds AppStream metadata with a manually maintained release history. Without automation, every release would require editing the XML by hand and it could easily become stale.

This is integrated into the existing `Build Release` workflow instead of using a separate `release: published` workflow. The release itself is created with `GITHUB_TOKEN`, and GitHub intentionally does not recursively trigger most workflows from events created by that token, so keeping the update in the same release run is more reliable.

## Dependency

This PR expects `packaging/io.github.AzPepoze.linux-wallpaperengine-gui.metainfo.xml` from #57 to exist on `dev` before the next tagged release runs.

## Validation

- branch is based on `dev`
- diff is limited to the release workflow and the new updater utility
- updater validates the version/date inputs, removes duplicate versions, and caps history at three entries
