### PR TITLE
fix(ci): sync AppStream release fix to main

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -91,6 +91,10 @@ jobs:
              - name: Update AppStream release history
                if: startsWith(github.ref, 'refs/tags/v')
                run: |
+                    # The release-version step intentionally modifies package.json for the build.
+                    # Restore it before switching from the tag checkout to the dev branch.
+                    git restore -- package.json
+
                     git fetch origin dev
                     git checkout -B dev origin/dev
 

--- a/packaging/io.github.AzPepoze.linux-wallpaperengine-gui.metainfo.xml
+++ b/packaging/io.github.AzPepoze.linux-wallpaperengine-gui.metainfo.xml
@@ -125,8 +125,8 @@
   </content_rating>
 
   <releases>
+    <release version="0.5.0" date="2026-08-16"/>
     <release version="0.4.8" date="2026-08-02"/>
     <release version="0.4.7" date="2026-06-10"/>
-    <release version="0.4.6" date="2026-06-04"/>
   </releases>
 </component>


### PR DESCRIPTION
## Summary

- restore `package.json` before switching from a release tag checkout to `dev`
- prevent future release workflows from failing during the AppStream metadata update
- repair the `0.5.0` AppStream release history on `main`