### PR TITLE
ci: refresh GitHub Actions and Linux build dependencies

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -21,7 +21,7 @@ jobs:
           timeout-minutes: 20
 
           steps:
-             - uses: actions/checkout@v4
+             - uses: actions/checkout@v6
 
              - name: Setup Bun
                uses: oven-sh/setup-bun@v2
@@ -29,13 +29,13 @@ jobs:
                     bun-version: '1'
 
              - name: Setup Go
-               uses: actions/setup-go@v5
+               uses: actions/setup-go@v7
                with:
                     go-version: 'stable'
                     cache-dependency-path: src/backend/go.sum
 
              - name: Cache Bun dependencies
-               uses: actions/cache@v4
+               uses: actions/cache@v5
                with:
                     path: ~/.bun/install/cache
                     key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -43,7 +43,7 @@ jobs:
                          bun-${{ runner.os }}-
 
              - name: Cache Electron
-               uses: actions/cache@v4
+               uses: actions/cache@v5
                with:
                     path: ~/.cache/electron
                     key: electron-${{ runner.os }}-${{ hashFiles('package.json') }}
@@ -51,7 +51,7 @@ jobs:
                          electron-${{ runner.os }}-
 
              - name: Cache APT packages
-               uses: actions/cache@v4
+               uses: actions/cache@v5
                id: apt-cache
                with:
                     path: /var/cache/apt/archives

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
           timeout-minutes: 30
 
           steps:
-             - uses: actions/checkout@v4
+             - uses: actions/checkout@v6
 
              - name: Setup Bun
                uses: oven-sh/setup-bun@v2
@@ -27,7 +27,7 @@ jobs:
                     bun-version: '1'
 
              - name: Setup Go
-               uses: actions/setup-go@v5
+               uses: actions/setup-go@v7
                with:
                     go-version: 'stable'
                     cache: true
@@ -37,7 +37,7 @@ jobs:
                run: bun utils/set-package-version.ts --mode=release
 
              - name: Cache dependencies
-               uses: actions/cache@v4
+               uses: actions/cache@v5
                with:
                     path: |
                          ~/.bun/install/cache
@@ -51,7 +51,7 @@ jobs:
                run: |
                     sudo apt-get update
                     sudo apt-get install -y --no-install-recommends \
-                      rpm libarchive-tools libgtk-3-dev libayatana-appindicator3-dev
+                      rpm libopenjp2-tools libgtk-3-dev libayatana-appindicator3-dev
                env:
                     DEBIAN_FRONTEND: noninteractive
 


### PR DESCRIPTION
## Summary

Refresh the GitHub Actions workflow dependencies and align the Linux release build prerequisites with the current electron-builder guidance.

## Changes

- Update `actions/checkout` from `v4` to `v6`.
- Update `actions/setup-go` from `v5` to `v7`.
- Update `actions/cache` from `v4` to `v5`.
- Keep GTK/AppIndicator development packages required by the Go systray backend.
- Replace `libarchive-tools` in the release workflow with `libopenjp2-tools`.
- Keep `rpm` explicitly installed because the release workflow builds an RPM target.

## Why

GitHub-hosted runner images are updated independently from the action versions pinned in workflow YAML, so the existing `@v4`/`@v5` references do not automatically move to newer action releases.

The project still needs `libgtk-3-dev` and `libayatana-appindicator3-dev` to compile the Linux systray backend. For distributable Linux builds, current electron-builder documentation lists `libopenjp2-tools`, and the RPM target requires `rpm`.

## Scope

Only these workflow files are changed:

- `.github/workflows/build-check.yml`
- `.github/workflows/build-release.yml`

No application/runtime code is changed.